### PR TITLE
Added bazel-x-edr-genit to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ bazel-bin
 bazel-genit
 bazel-out
 bazel-testlogs
-
+bazel-x-edr-genit
 


### PR DESCRIPTION
Added bazel-x-edr-genit to git ignore since that is now where this ends up building the target with the new name of this repo.