### PR TITLE
Added nested ranges for multi-dimensional (nested) for loops

### DIFF
--- a/genit/BUILD
+++ b/genit/BUILD
@@ -32,6 +32,7 @@ cc_library(
         "filter_iterator.h",
         "iterator_facade.h",
         "iterator_range.h",
+        "nested_range.h",
         "stride_iterator.h",
         "transform_iterator.h",
         "zip_iterator.h",
@@ -144,6 +145,15 @@ cc_test(
     srcs = [
         "iterator_range_test.cc",
     ],
+    deps = [
+        ":iterators",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "nested_range_test",
+    srcs = ["nested_range_test.cc"],
     deps = [
         ":iterators",
         "@com_google_googletest//:gtest_main",

--- a/genit/nested_range.h
+++ b/genit/nested_range.h
@@ -21,14 +21,11 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
-#include <variant>
 
-#include "absl/types/variant.h"
 #include "absl/utility/utility.h"
 #include "genit/iterator_facade.h"
 #include "genit/iterator_range.h"
 #include "genit/zip_iterator.h"
-#include "iterator_range.h"
 
 namespace genit {
 

--- a/genit/nested_range.h
+++ b/genit/nested_range.h
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GENIT_NESTED_RANGE_H_
+#define GENIT_NESTED_RANGE_H_
+
+#include <iterator>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "absl/types/variant.h"
+#include "absl/utility/utility.h"
+#include "genit/iterator_facade.h"
+#include "genit/iterator_range.h"
+#include "genit/zip_iterator.h"
+#include "iterator_range.h"
+
+namespace genit {
+
+// Given a sequence of iterator ranges, nest them to provide a single
+// multi-dimensional iterator.
+//
+// For example,
+//
+// std::vector<int> v1 = {1,2,3};
+// const std::list<int> v2 = {4, 5, 6};
+// auto range = NestRanges(v1, v2);
+// for (auto [x, y] : range) {
+//   // Produces:
+//   // x = 1; y = 4;
+//   // x = 1; y = 5;
+//   // x = 1; y = 6;
+//   // x = 2; y = 4;
+//   // x = 2; y = 5;
+//   // x = 2; y = 6;
+//   ...
+// }
+//
+
+namespace nested_range_detail {
+
+struct BeginTag {};
+struct EndTag {};
+
+template <typename... Ranges>
+using NestedRangeCategory = zip_iterator_detail::LeastPermissive<
+    std::bidirectional_iterator_tag,
+    zip_iterator_detail::ReduceToStdIterCategory<typename std::iterator_traits<
+        RangeIteratorType<Ranges>>::iterator_category>...>;
+
+template <typename... Ranges>
+using InnerRangeCategory = zip_iterator_detail::LeastPermissive<
+    std::forward_iterator_tag,
+    zip_iterator_detail::ReduceToStdIterCategory<typename std::iterator_traits<
+        RangeIteratorType<Ranges>>::iterator_category>...>;
+
+}  // namespace nested_range_detail
+
+template <typename FirstRange, typename... Ranges>
+class NestedRange {
+  static_assert(
+      std::is_convertible_v<nested_range_detail::InnerRangeCategory<Ranges...>,
+                            std::forward_iterator_tag>,
+      "NestedRange requires inner ranges to be at least forward iterators "
+      "(multi-pass).");
+
+public:
+  template <typename... OtherRanges>
+  explicit NestedRange(OtherRanges&&... ranges)
+      : ranges_(std::forward<OtherRanges>(ranges)...) {}
+
+  using OutputRefType =
+      std::tuple<decltype(*std::declval<RangeIteratorType<FirstRange>>()),
+                 decltype(*std::declval<RangeIteratorType<Ranges>>())...>;
+  static constexpr size_t kNumberOfRanges = sizeof...(Ranges) + 1;
+  using IndexSeq = absl::make_index_sequence<kNumberOfRanges>;
+
+  // Allows iterating over a NestedRange.
+  class NestedIterator
+      : public IteratorFacade<
+            NestedIterator, OutputRefType,
+            nested_range_detail::NestedRangeCategory<
+                FirstRange, Ranges...>> {
+   public:
+    NestedIterator(nested_range_detail::BeginTag,
+                   const NestedRange<FirstRange, Ranges...>* nested)
+        : nested_(nested) {
+      MakeBegin(IndexSeq());
+    }
+    NestedIterator(nested_range_detail::EndTag,
+                   const NestedRange<FirstRange, Ranges...>* nested)
+        : nested_(nested) {
+      MakeEnd(IndexSeq());
+    }
+
+    // Default constructor:
+    NestedIterator() : nested_(nullptr), it_tuple_() {}
+
+    NestedIterator(const NestedIterator&) = default;
+    NestedIterator(NestedIterator&&) = default;
+
+   private:
+    friend class IteratorFacadePrivateAccess<NestedIterator>;
+
+    template <size_t... Ids>
+    void MakeBegin(absl::index_sequence<Ids...> ids) {
+      using std::begin;
+      ((void)(std::get<Ids>(it_tuple_) =
+          begin(std::get<Ids>(nested_->ranges_))), ...);
+    }
+
+    template <size_t... Ids>
+    void MakeEnd(absl::index_sequence<Ids...> ids) {
+      using std::begin;
+      using std::end;
+      ((void)(std::get<Ids>(it_tuple_) =
+          (Ids == 0 ?
+              end(std::get<Ids>(nested_->ranges_)) :
+              begin(std::get<Ids>(nested_->ranges_)))), ...);
+    }
+
+    template <size_t... Ids>
+    OutputRefType Dereference(absl::index_sequence<Ids...> ids) const {
+      return OutputRefType{(*std::get<Ids>(it_tuple_))...};
+    }
+    OutputRefType Dereference() const { return Dereference(IndexSeq()); }
+
+    template <size_t... Ids>
+    bool IsEqual(const NestedIterator& rhs,
+                 absl::index_sequence<Ids...> ids) const {
+      // Require all iterators to match.
+      return ((std::get<Ids>(it_tuple_) == std::get<Ids>(rhs.it_tuple_)) &&
+              ...);
+    }
+    bool IsEqual(const NestedIterator& rhs) const {
+      return IsEqual(rhs, IndexSeq());
+    }
+
+    template <size_t Id>
+    bool IncrementOrWrap() {
+      using std::begin;
+      using std::end;
+      if constexpr (Id == 0) {
+        ++std::get<0>(it_tuple_);
+        return true;
+      } else {
+        ++std::get<Id>(it_tuple_);
+        if (std::get<Id>(it_tuple_) == end(std::get<Id>(nested_->ranges_))) {
+          std::get<Id>(it_tuple_) = begin(std::get<Id>(nested_->ranges_));
+          return false;
+        }
+        return true;
+      }
+    }
+    template <size_t... Ids>
+    void Increment(absl::index_sequence<Ids...> ids) {
+      (IncrementOrWrap<kNumberOfRanges - Ids - 1>() || ...);
+    }
+    void Increment() { Increment(IndexSeq()); }
+
+    template <size_t Id>
+    bool DecrementOrWrap() {
+      using std::begin;
+      using std::end;
+      if constexpr (Id == 0) {
+        --std::get<0>(it_tuple_);
+        return true;
+      } else {
+        if (std::get<Id>(it_tuple_) == begin(std::get<Id>(nested_->ranges_))) {
+          std::get<Id>(it_tuple_) = end(std::get<Id>(nested_->ranges_));
+          --std::get<Id>(it_tuple_);
+          return false;
+        }
+        --std::get<Id>(it_tuple_);
+        return true;
+      }
+    }
+    template <size_t... Ids>
+    void Decrement(absl::index_sequence<Ids...> ids) {
+      (DecrementOrWrap<kNumberOfRanges - Ids - 1>() || ...);
+    }
+    void Decrement() { Decrement(IndexSeq()); }
+
+    const NestedRange<FirstRange, Ranges...>* nested_;
+    std::tuple<RangeIteratorType<FirstRange>,
+               RangeIteratorType<Ranges>...> it_tuple_;
+  };
+  friend class NestedIterator;
+
+  using iterator = NestedIterator;
+  using value_type = typename std::iterator_traits<NestedIterator>::value_type;
+  using reference = typename std::iterator_traits<NestedIterator>::reference;
+
+  iterator begin() const {
+    return NestedIterator(nested_range_detail::BeginTag{}, this);
+  }
+  iterator end() const {
+    return NestedIterator(nested_range_detail::EndTag{}, this);
+  }
+
+ private:
+  std::tuple<FirstRange, Ranges...> ranges_;
+};
+
+// Deduction guide
+template <typename... OtherRanges>
+NestedRange(OtherRanges&&... ranges)
+    -> NestedRange<std::decay_t<OtherRanges>...>;
+
+// Deduction function to create NestedRange for older compilers (gcc<11).
+template <typename... OtherRanges>
+auto MakeNestedRange(OtherRanges&&... ranges) {
+  return NestedRange<std::decay_t<OtherRanges>...>(
+      std::forward<OtherRanges>(ranges)...);
+}
+
+// Convenience wrapper to nest a sequence of ranges.  Keeps a
+// light-weight copy to the supplied range (avoids a deep copy).  This works on
+// ranges on which calling MakeIteratorRange() makes sense.
+template <typename... Containers>
+auto NestRanges(Containers&&... ranges) {
+  return MakeNestedRange(
+      MakeIteratorRange(std::forward<Containers>(ranges))...);
+}
+
+}  // namespace genit
+
+#endif  // GENIT_NESTED_RANGE_H_

--- a/genit/nested_range_test.cc
+++ b/genit/nested_range_test.cc
@@ -1,0 +1,207 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "genit/nested_range.h"
+
+#include <array>
+#include <forward_list>
+#include <functional>
+#include <iterator>
+#include <list>
+#include <sstream>
+#include <vector>
+
+#include "genit/iterator_range.h"
+#include "genit/zip_iterator.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace genit {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::DoubleNear;
+using ::testing::Ne;
+
+template <typename Category, typename Range>
+void ExpectIteratorCategory(Range&& range, Category&& category) {
+  using std::begin;
+  static_assert(
+      std::is_same<typename std::iterator_traits<decltype(begin(
+                       std::forward<Range>(range)))>::iterator_category,
+                   Category>::value,
+      "");
+}
+
+struct NonAssignableType {
+  explicit NonAssignableType(int x) : value(x) {}
+  NonAssignableType(const NonAssignableType&) = delete;
+  NonAssignableType& operator=(const NonAssignableType&) = delete;
+  NonAssignableType(NonAssignableType&&) = delete;
+  NonAssignableType& operator=(NonAssignableType&&) = delete;
+
+  int value = 0;
+};
+
+struct ConvertibleType {
+  explicit ConvertibleType(int x) : value(x) {}
+  operator int() const { return value; }  // NOLINT
+  int value = 0;
+};
+
+TEST(NestedRange, EmptyRange) {
+  std::vector<int> v;
+  const auto range = NestRanges(v, v, v);
+  EXPECT_THAT(range.begin(), Eq(range.end()));
+}
+
+TEST(NestedRange, SomeEmptyRanges) {
+  std::vector<int> xs = {1, 2, 3};
+  std::vector<int> ys = {4, 5, 6};
+  std::vector<int> empty;
+  const auto range = NestRanges(empty, xs, empty, ys, empty);
+  EXPECT_THAT(range.begin(), Eq(range.end()));
+}
+
+TEST(NestedRange, NonEmptyRange) {
+  std::vector<int> v = {1, 2, 3};
+  const auto range = NestRanges(v, v, v);
+  EXPECT_THAT(range.begin(), Ne(range.end()));
+}
+
+TEST(NestedRange, Increment) {
+  std::vector<int> xs = {1, 2, 3};
+  std::vector<int> ys = {4, 5, 6};
+  const auto range = NestRanges(xs, ys);
+
+  auto it = range.begin();
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      auto [x, y] = *it;
+      EXPECT_THAT(x, Eq(i + 1));
+      EXPECT_THAT(y, Eq(j + 4));
+      ++it;
+    }
+  }
+  EXPECT_THAT(it, Eq(range.end()));
+}
+
+TEST(NestedRange, Decrement) {
+  std::vector<int> xs = {1, 2, 3};
+  std::vector<int> ys = {4, 5, 6};
+  const auto range = NestRanges(xs, ys);
+
+  auto it = range.end();
+  for (int i = 2; i >= 0; --i) {
+    for (int j = 2; j >= 0; --j) {
+      --it;
+      auto [x, y] = *it;
+      EXPECT_THAT(x, Eq(i + 1));
+      EXPECT_THAT(y, Eq(j + 4));
+    }
+  }
+  EXPECT_THAT(it, Eq(range.begin()));
+}
+
+TEST(NestedRange, DecrementAndIncrement) {
+  std::vector<int> xs = {1, 2, 3};
+  std::vector<int> ys = {4, 5, 6};
+  const auto range = NestRanges(xs, ys);
+
+  for (auto it = range.begin(); it != range.end(); ++it) {
+    const auto copy = it;
+    EXPECT_THAT(--(++(it)), Eq(copy));
+  }
+
+  for (auto it = range.end(); it != range.begin(); --it) {
+    const auto copy = it;
+    EXPECT_THAT(++(--(it)), Eq(copy));
+  }
+}
+
+TEST(NestedRange, DecrementAndIncrementBidirectional) {
+  std::list<int> xs = {1, 2, 3};
+  std::vector<int> ys = {4, 5, 6};
+  const auto range = NestRanges(xs, ys);
+
+  for (auto it = range.begin(); it != range.end(); ++it) {
+    const auto copy = it;
+    EXPECT_THAT(--(++(it)), Eq(copy));
+  }
+
+  for (auto it = range.end(); it != range.begin(); --it) {
+    const auto copy = it;
+    EXPECT_THAT(++(--(it)), Eq(copy));
+  }
+}
+
+TEST(NestedRange, SingleRangeForLoop) {
+  const std::vector<int> values = {1, 2, 3};
+  const auto range = NestRanges(values);
+
+  // Test usage in range-based for loop.
+  auto expected = values.begin();
+  for (const auto& [x] : range) {
+    EXPECT_THAT(x, Eq(*expected));
+    ++expected;
+  }
+  EXPECT_THAT(expected, Eq(values.end()));
+}
+
+TEST(NestedRange, NonAssignableType) {
+  std::array<NonAssignableType, 3> v = {
+      NonAssignableType{1}, NonAssignableType{2}, NonAssignableType{3}};
+  const auto range = NestRanges(v);
+
+  int i = 1;
+  for (const auto& [x] : range) {
+    EXPECT_THAT(x.value, Eq(i++));
+  }
+  EXPECT_THAT(i, Eq(4));
+}
+
+TEST(NestedRange, ConcatVariousRangeTypes) {
+  const std::vector<int> xs = {1, 2, 3};
+  std::vector<double> ys = {4.1, 5.2, 6.3};
+  const auto range = NestRanges(xs, ys);
+
+  auto it = range.begin();
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      auto [x, y] = *it;
+      EXPECT_THAT(x, Eq(i + 1));
+      EXPECT_THAT(y, DoubleNear(j + 4.1 + j * 0.1, 1e-14));
+      ++it;
+    }
+  }
+}
+
+TEST(NestedRange, IteratorTag) {
+  std::vector<int> random;
+  std::list<int> bidirectional;
+  std::forward_list<int> forward;
+
+  const auto random_range = NestRanges(random);
+  ExpectIteratorCategory(random_range, std::bidirectional_iterator_tag{});
+
+  const auto bidir_range = NestRanges(random, bidirectional);
+  ExpectIteratorCategory(bidir_range, std::bidirectional_iterator_tag{});
+
+  const auto forward_range = NestRanges(random, bidirectional, forward);
+  ExpectIteratorCategory(forward_range, std::forward_iterator_tag{});
+}
+
+}  // namespace
+}  // namespace genit


### PR DESCRIPTION
Added nested ranges for multi-dimensional (nested) for loops

This allows something like this:

```
for (int i : IndexRange(0, 10)) {
  for (int j : IndexRange(0, 5)) {
    // use i,j in 2d array
  }
}
```

to be replaced by:

```
for (auto [i, j] : NestRanges(IndexRange(0, 10), IndexRange(0, 5))) {
  // use i,j in 2d array
}
```