### PR TITLE
Use ranges consistently to solve life-time issues

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,226 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: NextLine
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/genit/adjacent_circular_iterator_test.cc
+++ b/genit/adjacent_circular_iterator_test.cc
@@ -244,8 +244,7 @@ TEST(AdjacentCircularIteratorTest, TripleIteratorNonAssignableType) {
   auto get_non_assignable = [](int) { return NonAssignableType(); };
 
   auto triplet_range = AdjacentElementsCircularRange<3>(
-      MakeTransformIterator(IndexIterator(0), std::cref(get_non_assignable)),
-      MakeTransformIterator(IndexIterator(5), std::cref(get_non_assignable)));
+      TransformRange(IndexRange(0, 5), get_non_assignable));
 
   for (auto triplet : triplet_range) {
     EXPECT_EQ(triplet.size(), 3);
@@ -261,15 +260,16 @@ TEST(AdjacentCircularIteratorTest, EmptyRangeIfRangeTooSmall) {
 TEST(AdjacentCircularIteratorTest, TwoPassesBothDirections) {
   const int values[] = {1, 2, 3, 4, 5};
   auto range = AdjacentElementsCircularRange<2>(values);
-  range = IteratorRange(range.begin(), range.end() + std::size(values));
+  auto two_turns =
+      IteratorRange(range.begin(), range.end() + std::size(values));
 
   int counter = 0;
-  for (const auto pair : range) {
+  for (const auto pair : two_turns) {
     EXPECT_EQ(pair.front(), 1 + (counter % 5));
     ++counter;
   }
   EXPECT_EQ(counter, 2 * std::size(values));
-  for (const auto pair : ReverseRange(range)) {
+  for (const auto pair : ReverseRange(two_turns)) {
     --counter;
     EXPECT_EQ(pair.front(), 1 + (counter % 5));
   }

--- a/genit/adjacent_iterator_test.cc
+++ b/genit/adjacent_iterator_test.cc
@@ -35,8 +35,7 @@ class NonAssignableType {
 };
 
 TEST(AdjacentIteratorTest, TripleIteratorComparison) {
-  auto triplet_range =
-      AdjacentElementsRange<3>(IndexIterator(0), IndexIterator(5));
+  auto triplet_range = AdjacentElementsRange<3>(IndexRange(0, 5));
   auto it = triplet_range.begin();
   auto it_end = triplet_range.end();
 
@@ -49,8 +48,7 @@ TEST(AdjacentIteratorTest, TripleIteratorComparison) {
 }
 
 TEST(AdjacentIteratorTest, TripleIteratorDereference) {
-  auto triplet_range =
-      AdjacentElementsRange<3>(IndexIterator(0), IndexIterator(5));
+  auto triplet_range = AdjacentElementsRange<3>(IndexRange(0, 5));
   auto it = triplet_range.begin();
 
   auto value = *it;
@@ -76,8 +74,7 @@ TEST(AdjacentIteratorTest, TripleIteratorDereference) {
 }
 
 TEST(AdjacentIteratorTest, TripleIteratorIncrementDecrement) {
-  auto triplet_range =
-      AdjacentElementsRange<3>(IndexIterator(0), IndexIterator(5));
+  auto triplet_range = AdjacentElementsRange<3>(IndexRange(0, 5));
   auto it = triplet_range.begin();
 
   ++it;
@@ -114,8 +111,7 @@ TEST(AdjacentIteratorTest, TripleIteratorIncrementDecrement) {
 }
 
 TEST(AdjacentIteratorTest, TripleIteratorRandomAccess) {
-  auto triplet_range =
-      AdjacentElementsRange<3>(IndexIterator(0), IndexIterator(5));
+  auto triplet_range = AdjacentElementsRange<3>(IndexRange(0, 5));
   auto it = triplet_range.begin();
   auto it_end = triplet_range.end();
 
@@ -200,8 +196,7 @@ TEST(AdjacentIteratorTest, TripleIteratorNonAssignableType) {
   auto get_non_assignable = [](int) { return NonAssignableType(); };
 
   auto triplet_range = AdjacentElementsRange<3>(
-      MakeTransformIterator(IndexIterator(0), std::cref(get_non_assignable)),
-      MakeTransformIterator(IndexIterator(5), std::cref(get_non_assignable)));
+      TransformRange(IndexRange(0, 5), get_non_assignable));
 
   for (auto triplet : triplet_range) {
     EXPECT_EQ(triplet.size(), 3);

--- a/genit/cached_iterator_test.cc
+++ b/genit/cached_iterator_test.cc
@@ -33,10 +33,9 @@ TEST(CachedIteratorTest, SquaringIterator) {
     return i * i;
   };
 
-  auto it = MakeCachedIterator(
-      MakeTransformIterator(v.begin(), std::cref(squaring_func)));
-  auto it_end = MakeCachedIterator(
-      MakeTransformIterator(v.end(), std::cref(squaring_func)));
+  auto c_range = CachedRange(TransformRange(v, squaring_func));
+  auto it = c_range.begin();
+  auto it_end = c_range.end();
 
   EXPECT_TRUE((std::is_same_v<decltype(*it), int>));
   EXPECT_FALSE(std::is_rvalue_reference_v<decltype(*it)>);

--- a/genit/circular_iterator.h
+++ b/genit/circular_iterator.h
@@ -42,7 +42,6 @@
 
 #include "genit/iterator_facade.h"
 #include "genit/iterator_range.h"
-#include "iterator_range.h"
 
 namespace genit {
 

--- a/genit/circular_iterator.h
+++ b/genit/circular_iterator.h
@@ -42,31 +42,29 @@
 
 #include "genit/iterator_facade.h"
 #include "genit/iterator_range.h"
+#include "iterator_range.h"
 
 namespace genit {
 
-// This class template implements an iterator which allows wrapping around the
-// range for a specified number of times.
-//
-// UnderlyingIter is the type of the underlying iterator that the
-// iterator uses to iterate the range.
-template <typename UnderlyingIter>
+template <typename BaseRange>
 class CircularIterator
     : public IteratorFacade<
-          CircularIterator<UnderlyingIter>,
-          decltype(*std::declval<UnderlyingIter>()),
-          typename std::iterator_traits<UnderlyingIter>::iterator_category> {
+          CircularIterator<BaseRange>,
+          decltype(*std::declval<RangeIteratorType<BaseRange>>()),
+          typename std::iterator_traits<
+              RangeIteratorType<BaseRange>>::iterator_category> {
  public:
   // Constructs an  iterator from an underlying iterator range.
   // The winding number specifies which turn this corresponds to. So, in the
   // usual case, if you want to iterate one turn around
   // the range [first, last), you would create iter(first, last, 0) for begin
   // and iter(first, last, 1) for end.
-  CircularIterator(const UnderlyingIter& it, const UnderlyingIter& it_end,
-                   int winding = 0)
-      : base_iter_(it), it_begin_(it), it_end_(it_end), winding_(winding) {
+  explicit CircularIterator(const BaseRange* base_range, int winding = 0)
+      : base_iter_(base_range->begin()),
+        base_range_(base_range),
+        winding_(winding) {
     // For empty range, normalize winding number to 0 to simplify comparison.
-    if (it_begin_ == it_end_) {
+    if (BaseBegin() == BaseEnd()) {
       winding_ = 0;
     }
   }
@@ -76,20 +74,30 @@ class CircularIterator
 
   friend class IteratorFacadePrivateAccess<CircularIterator>;
 
-  using Reference = decltype(*std::declval<UnderlyingIter>());
+  using BaseIter = RangeIteratorType<BaseRange>;
+  using Reference = decltype(*std::declval<BaseIter>());
+
+  BaseIter BaseBegin() const {
+    using std::begin;
+    return begin(*base_range_);
+  }
+  BaseIter BaseEnd() const {
+    using std::end;
+    return end(*base_range_);
+  }
 
   Reference Dereference() const { return *base_iter_; }
   void Increment() {
     ++base_iter_;
-    if (base_iter_ == it_end_) {
-      base_iter_ = it_begin_;
+    if (base_iter_ == BaseEnd()) {
+      base_iter_ = BaseBegin();
       ++winding_;
     }
   }
   void Decrement() {
-    if (base_iter_ == it_begin_) {
+    if (base_iter_ == BaseBegin()) {
       --winding_;
-      base_iter_ = it_end_;
+      base_iter_ = BaseEnd();
     }
     --base_iter_;
   }
@@ -98,30 +106,68 @@ class CircularIterator
   }
   int DistanceTo(const CircularIterator& rhs) const {
     return (rhs.base_iter_ - base_iter_) +
-           (rhs.winding_ - winding_) * (it_end_ - it_begin_);
+           (rhs.winding_ - winding_) * (BaseEnd() - BaseBegin());
   }
   void Advance(int n) {
     base_iter_ += n;
-    const int distance_from_begin = base_iter_ - it_begin_;
-    const int range_size = it_end_ - it_begin_;
+    const int distance_from_begin = base_iter_ - BaseBegin();
+    const int range_size = BaseEnd() - BaseBegin();
     // Apply % twice to allow for negative distances.
     base_iter_ =
-        it_begin_ +
+        BaseBegin() +
         (((distance_from_begin % range_size) + range_size) % range_size);
     winding_ += distance_from_begin / range_size;
   }
 
   // Stores the set of  iterators.
-  UnderlyingIter base_iter_;
-  UnderlyingIter it_begin_;
-  UnderlyingIter it_end_;
+  BaseIter base_iter_;
+  const BaseRange* base_range_;
   int winding_;
 };
 
-// Deduction guide
-template <typename Iter>
-CircularIterator(Iter&& begin, Iter&& end)
-    -> CircularIterator<std::decay_t<Iter>>;
+// This class template implements a range which allows wrapping around the
+// underlying range for a specified number of times.
+//
+// BaseRange is the type of the underlying range to circle over.
+template <typename BaseRange>
+class CircularRangeT
+    : public AliasRangeFacade<CircularRangeT<BaseRange>, BaseRange,
+                              CircularIterator<BaseRange>> {
+ public:
+  using CircIter = CircularIterator<BaseRange>;
+  using BaseFacade =
+      AliasRangeFacade<CircularRangeT<BaseRange>, BaseRange, CircIter>;
+
+  // Constructor from a Range
+  template <typename OtherRange>
+  explicit CircularRangeT(OtherRange&& r, int windings, bool connect)
+      : BaseFacade(std::forward<OtherRange>(r)),
+        windings_(windings),
+        connect_(connect) {}
+
+  // Default assignment operator
+  CircularRangeT& operator=(const CircularRangeT&) = default;
+  CircularRangeT& operator=(CircularRangeT&&) = default;
+  CircularRangeT(const CircularRangeT&) = default;
+  CircularRangeT(CircularRangeT&&) = default;
+
+ private:
+  friend class AliasRangeFacadePrivateAccess<CircularRangeT<BaseRange>>;
+
+  auto Begin(const BaseRange& base_range) const {
+    return CircIter(&base_range, 0);
+  }
+  auto End(const BaseRange& base_range) const {
+    auto e = CircIter(&base_range, windings_);
+    if (connect_ && e != Begin(base_range)) {
+      ++e;
+    }
+    return e;
+  }
+
+  int windings_ = 1;
+  bool connect_ = false;
+};
 
 // This convenient wrapper function produces a range of circular iterators from
 // a given range, wrapping around windings number of times. See CircularIterator
@@ -129,10 +175,9 @@ CircularIterator(Iter&& begin, Iter&& end)
 template <typename Range>
 auto CircularRange(Range&& range, int windings = 1) {
   assert(windings >= 0);
-  using std::begin;
-  using std::end;
-  return IteratorRange(CircularIterator(begin(range), end(range)),
-                       CircularIterator(begin(range), end(range), windings));
+  return CircularRangeT<decltype(MoveOrAliasRange(std::forward<Range>(range)))>(
+      MoveOrAliasRange(std::forward<Range>(range)), windings,
+      /*connect=*/false);
 }
 
 // This convenient wrapper function produces a range of  circular iterators from
@@ -141,8 +186,7 @@ auto CircularRange(Range&& range, int windings = 1) {
 template <typename Iter>
 auto CircularRange(const Iter& first, const Iter& last, int windings = 1) {
   assert(windings >= 0);
-  return IteratorRange(CircularIterator(first, last),
-                       CircularIterator(first, last, windings));
+  return CircularRange(MakeIteratorRange(first, last), windings);
 }
 
 // This convenient wrapper function produces a range of circular iterators from
@@ -151,15 +195,10 @@ auto CircularRange(const Iter& first, const Iter& last, int windings = 1) {
 //
 // Range [x0, x1, ..., xn] -> Range [x0, x1, ..., xn, x0].
 template <typename Range>
-auto CircularConnectRange(Range&& range) {
-  using std::begin;
-  using std::end;
-  CircularIterator b(begin(range), end(range));
-  CircularIterator e(begin(range), end(range), 1);
-  if (b != e) {
-    ++e;
-  }
-  return IteratorRange(std::move(b), std::move(e));
+auto CircularConnectRange(Range&& range, int windings = 1) {
+  assert(windings >= 0);
+  return CircularRangeT<decltype(MoveOrAliasRange(std::forward<Range>(range)))>(
+      MoveOrAliasRange(std::forward<Range>(range)), windings, /*connect=*/true);
 }
 
 // This convenient wrapper function produces a range of  circular iterators from
@@ -169,13 +208,9 @@ auto CircularConnectRange(Range&& range) {
 //
 // Range [x0, x1, ..., xn] -> Range [x0, x1, ..., xn, x0].
 template <typename Iter>
-auto CircularConnectRange(const Iter& first, const Iter& last) {
-  CircularIterator begin(first, last);
-  CircularIterator end(first, last, 1);
-  if (begin != end) {
-    ++end;
-  }
-  return IteratorRange(begin, end);
+auto CircularConnectRange(const Iter& first, const Iter& last,
+                          int windings = 1) {
+  return CircularConnectRange(MakeIteratorRange(first, last), windings);
 }
 
 }  // namespace genit

--- a/genit/circular_iterator_test.cc
+++ b/genit/circular_iterator_test.cc
@@ -39,7 +39,7 @@ class NonAssignableType {
 };
 
 TEST(CircularIteratorTest, IteratorComparison) {
-  auto range = CircularRange(IndexIterator(0), IndexIterator(5));
+  auto range = CircularRange(IndexRange(0, 5));
   auto it = range.begin();
   auto it_end = range.end();
 
@@ -52,14 +52,14 @@ TEST(CircularIteratorTest, IteratorComparison) {
 }
 
 TEST(CircularIteratorTest, IteratorDereference) {
-  auto range = CircularRange(IndexIterator(0), IndexIterator(5));
+  auto range = CircularRange(IndexRange(0, 5));
   auto it = range.begin();
 
   EXPECT_EQ(*it, 0);
 }
 
 TEST(CircularIteratorTest, IteratorIncrementDecrement) {
-  auto range = CircularRange(IndexIterator(0), IndexIterator(5));
+  auto range = CircularRange(IndexRange(0, 5));
   auto it = range.begin();
 
   ++it;
@@ -96,7 +96,7 @@ TEST(CircularIteratorTest, IteratorIncrementDecrement) {
 }
 
 TEST(CircularIteratorTest, IteratorRandomAccess) {
-  auto range = CircularRange(IndexIterator(0), IndexIterator(5));
+  auto range = CircularRange(IndexRange(0, 5));
   auto it = range.begin();
   auto it_end = range.end();
 
@@ -157,7 +157,7 @@ TEST(CircularIteratorTest, IteratorFromContainer) {
 
 TEST(CircularIteratorTest, MultipleWindings) {
   constexpr int n_windings = 7;
-  auto range = CircularRange(IndexIterator(0), IndexIterator(6), n_windings);
+  auto range = CircularRange(IndexRange(0, 6), n_windings);
 
   int counter = 0;
   for (const int n : range) {
@@ -203,9 +203,8 @@ TEST(CircularIteratorTest, ValueIncrementIterator) {
 TEST(CircularIteratorTest, IteratorNonAssignableType) {
   auto get_non_assignable = [](int x) { return NonAssignableType(x); };
 
-  auto range = CircularRange(
-      MakeTransformIterator(IndexIterator(0), std::cref(get_non_assignable)),
-      MakeTransformIterator(IndexIterator(5), std::cref(get_non_assignable)));
+  auto range =
+      CircularRange(TransformRange(IndexRange(0, 5), get_non_assignable));
 
   int expected = 0;
   for (auto t : range) {

--- a/genit/concat_range.h
+++ b/genit/concat_range.h
@@ -309,22 +309,21 @@ class ConcatRange {
 // Deduction guide
 template <typename... OtherRanges>
 ConcatRange(OtherRanges&&... ranges)
-    -> ConcatRange<std::decay_t<OtherRanges>...>;
+    -> ConcatRange<RangeDecayType<OtherRanges>...>;
 
 // Deduction function to create ConcatRange for older compilers (gcc<11).
 template <typename... OtherRanges>
 auto MakeConcatRange(OtherRanges&&... ranges) {
-  return ConcatRange<std::decay_t<OtherRanges>...>(
+  return ConcatRange<RangeDecayType<OtherRanges>...>(
       std::forward<OtherRanges>(ranges)...);
 }
 
-// Convenience wrapper to concatenate a sequence of ranges.  Keeps a
-// light-weight copy to the supplied range (avoids a deep copy).  This works on
-// ranges on which calling MakeIteratorRange() makes sense.
+// Convenience wrapper to concatenate a sequence of ranges. Keeps a
+// iterator pairs to the supplied ranges if they are lvalue references.
+// Makes a copy/move of the supplied ranges if they are rvalue references.
 template <typename... Containers>
 auto ConcatenateRanges(Containers&&... ranges) {
-  return MakeConcatRange(
-      MakeIteratorRange(std::forward<Containers>(ranges))...);
+  return MakeConcatRange(MoveOrAliasRange(std::forward<Containers>(ranges))...);
 }
 
 }  // namespace genit

--- a/genit/filter_iterator_test.cc
+++ b/genit/filter_iterator_test.cc
@@ -75,7 +75,7 @@ TEST(FilterIteratorTest, EmptyRangeOnFalsePredicate) {
 TEST(FilterIteratorTest, LambdaPredicate) {
   const int xs[] = {1, 2, 3, 4, 5};
   auto predicate = [](int x) { return false; };
-  const auto empty = FilterRange(xs, std::cref(predicate));
+  const auto empty = FilterRange(xs, predicate);
   EXPECT_EQ(empty.begin(), empty.end());
   const auto other_empty = FilterRange(xs, std::function<bool(int)>(predicate));
   EXPECT_EQ(other_empty.begin(), other_empty.end());
@@ -160,8 +160,9 @@ TEST(FilterIteratorTest, IteratorCategory) {
 
   std::istringstream input("Some input");
   ExpectIteratorCategory(
-      MakeFilterIterator(std::istream_iterator<char>(input),
-                         std::istream_iterator<char>(), TruePredicate{}),
+      begin(FilterRange(MakeIteratorRange(std::istream_iterator<char>(input),
+                                          std::istream_iterator<char>()),
+                        TruePredicate{})),
       std::input_iterator_tag{});
 }
 

--- a/genit/nested_range.h
+++ b/genit/nested_range.h
@@ -26,7 +26,6 @@
 #include "genit/iterator_facade.h"
 #include "genit/iterator_range.h"
 #include "genit/zip_iterator.h"
-#include "iterator_range.h"
 
 namespace genit {
 

--- a/genit/nested_range.h
+++ b/genit/nested_range.h
@@ -26,6 +26,7 @@
 #include "genit/iterator_facade.h"
 #include "genit/iterator_range.h"
 #include "genit/zip_iterator.h"
+#include "iterator_range.h"
 
 namespace genit {
 
@@ -68,171 +69,177 @@ using InnerRangeCategory = zip_iterator_detail::LeastPermissive<
 
 }  // namespace nested_range_detail
 
+// Allows iterating over a NestedRange.
 template <typename FirstRange, typename... Ranges>
-class NestedRange {
-  static_assert(
-      std::is_convertible_v<nested_range_detail::InnerRangeCategory<Ranges...>,
-                            std::forward_iterator_tag>,
-      "NestedRange requires inner ranges to be at least forward iterators "
-      "(multi-pass).");
-
-public:
-  template <typename... OtherRanges>
-  explicit NestedRange(OtherRanges&&... ranges)
-      : ranges_(std::forward<OtherRanges>(ranges)...) {}
-
+class NestedIterator
+    : public IteratorFacade<
+          NestedIterator<FirstRange, Ranges...>,
+          std::tuple<decltype(*std::declval<RangeIteratorType<FirstRange>>()),
+                     decltype(*std::declval<RangeIteratorType<Ranges>>())...>,
+          nested_range_detail::NestedRangeCategory<FirstRange, Ranges...>> {
+ public:
   using OutputRefType =
       std::tuple<decltype(*std::declval<RangeIteratorType<FirstRange>>()),
                  decltype(*std::declval<RangeIteratorType<Ranges>>())...>;
   static constexpr size_t kNumberOfRanges = sizeof...(Ranges) + 1;
   using IndexSeq = absl::make_index_sequence<kNumberOfRanges>;
 
-  // Allows iterating over a NestedRange.
-  class NestedIterator
-      : public IteratorFacade<
-            NestedIterator, OutputRefType,
-            nested_range_detail::NestedRangeCategory<
-                FirstRange, Ranges...>> {
-   public:
-    NestedIterator(nested_range_detail::BeginTag,
-                   const NestedRange<FirstRange, Ranges...>* nested)
-        : nested_(nested) {
-      MakeBegin(IndexSeq());
-    }
-    NestedIterator(nested_range_detail::EndTag,
-                   const NestedRange<FirstRange, Ranges...>* nested)
-        : nested_(nested) {
-      MakeEnd(IndexSeq());
-    }
-
-    // Default constructor:
-    NestedIterator() : nested_(nullptr), it_tuple_() {}
-
-    NestedIterator(const NestedIterator&) = default;
-    NestedIterator(NestedIterator&&) = default;
-
-   private:
-    friend class IteratorFacadePrivateAccess<NestedIterator>;
-
-    template <size_t... Ids>
-    void MakeBegin(absl::index_sequence<Ids...> ids) {
-      using std::begin;
-      ((void)(std::get<Ids>(it_tuple_) =
-          begin(std::get<Ids>(nested_->ranges_))), ...);
-    }
-
-    template <size_t... Ids>
-    void MakeEnd(absl::index_sequence<Ids...> ids) {
-      using std::begin;
-      using std::end;
-      ((void)(std::get<Ids>(it_tuple_) =
-          (Ids == 0 ?
-              end(std::get<Ids>(nested_->ranges_)) :
-              begin(std::get<Ids>(nested_->ranges_)))), ...);
-    }
-
-    template <size_t... Ids>
-    OutputRefType Dereference(absl::index_sequence<Ids...> ids) const {
-      return OutputRefType{(*std::get<Ids>(it_tuple_))...};
-    }
-    OutputRefType Dereference() const { return Dereference(IndexSeq()); }
-
-    template <size_t... Ids>
-    bool IsEqual(const NestedIterator& rhs,
-                 absl::index_sequence<Ids...> ids) const {
-      // Require all iterators to match.
-      return ((std::get<Ids>(it_tuple_) == std::get<Ids>(rhs.it_tuple_)) &&
-              ...);
-    }
-    bool IsEqual(const NestedIterator& rhs) const {
-      return IsEqual(rhs, IndexSeq());
-    }
-
-    template <size_t Id>
-    bool IncrementOrWrap() {
-      using std::begin;
-      using std::end;
-      if constexpr (Id == 0) {
-        ++std::get<0>(it_tuple_);
-        return true;
-      } else {
-        ++std::get<Id>(it_tuple_);
-        if (std::get<Id>(it_tuple_) == end(std::get<Id>(nested_->ranges_))) {
-          std::get<Id>(it_tuple_) = begin(std::get<Id>(nested_->ranges_));
-          return false;
-        }
-        return true;
-      }
-    }
-    template <size_t... Ids>
-    void Increment(absl::index_sequence<Ids...> ids) {
-      (IncrementOrWrap<kNumberOfRanges - Ids - 1>() || ...);
-    }
-    void Increment() { Increment(IndexSeq()); }
-
-    template <size_t Id>
-    bool DecrementOrWrap() {
-      using std::begin;
-      using std::end;
-      if constexpr (Id == 0) {
-        --std::get<0>(it_tuple_);
-        return true;
-      } else {
-        if (std::get<Id>(it_tuple_) == begin(std::get<Id>(nested_->ranges_))) {
-          std::get<Id>(it_tuple_) = end(std::get<Id>(nested_->ranges_));
-          --std::get<Id>(it_tuple_);
-          return false;
-        }
-        --std::get<Id>(it_tuple_);
-        return true;
-      }
-    }
-    template <size_t... Ids>
-    void Decrement(absl::index_sequence<Ids...> ids) {
-      (DecrementOrWrap<kNumberOfRanges - Ids - 1>() || ...);
-    }
-    void Decrement() { Decrement(IndexSeq()); }
-
-    const NestedRange<FirstRange, Ranges...>* nested_;
-    std::tuple<RangeIteratorType<FirstRange>,
-               RangeIteratorType<Ranges>...> it_tuple_;
-  };
-  friend class NestedIterator;
-
-  using iterator = NestedIterator;
-  using value_type = typename std::iterator_traits<NestedIterator>::value_type;
-  using reference = typename std::iterator_traits<NestedIterator>::reference;
-
-  iterator begin() const {
-    return NestedIterator(nested_range_detail::BeginTag{}, this);
+  NestedIterator(nested_range_detail::BeginTag,
+                 const std::tuple<FirstRange, Ranges...>* ranges)
+      : ranges_(ranges) {
+    MakeBegin(IndexSeq());
   }
-  iterator end() const {
-    return NestedIterator(nested_range_detail::EndTag{}, this);
+  NestedIterator(nested_range_detail::EndTag,
+                 const std::tuple<FirstRange, Ranges...>* ranges)
+      : ranges_(ranges) {
+    MakeEnd(IndexSeq());
   }
+
+  // Default constructor:
+  NestedIterator() : ranges_(nullptr), it_tuple_() {}
+
+  NestedIterator(const NestedIterator&) = default;
+  NestedIterator(NestedIterator&&) = default;
+  NestedIterator& operator=(const NestedIterator&) = default;
+  NestedIterator& operator=(NestedIterator&&) = default;
 
  private:
-  std::tuple<FirstRange, Ranges...> ranges_;
+  friend class IteratorFacadePrivateAccess<NestedIterator>;
+
+  template <size_t... Ids>
+  void MakeBegin(absl::index_sequence<Ids...> ids) {
+    using std::begin;
+    ((void)(std::get<Ids>(it_tuple_) = begin(std::get<Ids>(*ranges_))), ...);
+  }
+
+  template <size_t... Ids>
+  void MakeEnd(absl::index_sequence<Ids...> ids) {
+    using std::begin;
+    using std::end;
+    ((void)(std::get<Ids>(it_tuple_) =
+                (Ids == 0 ? end(std::get<Ids>(*ranges_))
+                          : begin(std::get<Ids>(*ranges_)))),
+     ...);
+  }
+
+  template <size_t... Ids>
+  OutputRefType Dereference(absl::index_sequence<Ids...> ids) const {
+    return OutputRefType{(*std::get<Ids>(it_tuple_))...};
+  }
+  OutputRefType Dereference() const { return Dereference(IndexSeq()); }
+
+  template <size_t... Ids>
+  bool IsEqual(const NestedIterator& rhs,
+               absl::index_sequence<Ids...> ids) const {
+    // Require all iterators to match.
+    return ((std::get<Ids>(it_tuple_) == std::get<Ids>(rhs.it_tuple_)) && ...);
+  }
+  bool IsEqual(const NestedIterator& rhs) const {
+    return IsEqual(rhs, IndexSeq());
+  }
+
+  template <size_t Id>
+  bool IncrementOrWrap() {
+    using std::begin;
+    using std::end;
+    if constexpr (Id == 0) {
+      ++std::get<0>(it_tuple_);
+      return true;
+    } else {
+      ++std::get<Id>(it_tuple_);
+      if (std::get<Id>(it_tuple_) == end(std::get<Id>(*ranges_))) {
+        std::get<Id>(it_tuple_) = begin(std::get<Id>(*ranges_));
+        return false;
+      }
+      return true;
+    }
+  }
+  template <size_t... Ids>
+  void Increment(absl::index_sequence<Ids...> ids) {
+    (IncrementOrWrap<kNumberOfRanges - Ids - 1>() || ...);
+  }
+  void Increment() { Increment(IndexSeq()); }
+
+  template <size_t Id>
+  bool DecrementOrWrap() {
+    using std::begin;
+    using std::end;
+    if constexpr (Id == 0) {
+      --std::get<0>(it_tuple_);
+      return true;
+    } else {
+      if (std::get<Id>(it_tuple_) == begin(std::get<Id>(*ranges_))) {
+        std::get<Id>(it_tuple_) = end(std::get<Id>(*ranges_));
+        --std::get<Id>(it_tuple_);
+        return false;
+      }
+      --std::get<Id>(it_tuple_);
+      return true;
+    }
+  }
+  template <size_t... Ids>
+  void Decrement(absl::index_sequence<Ids...> ids) {
+    (DecrementOrWrap<kNumberOfRanges - Ids - 1>() || ...);
+  }
+  void Decrement() { Decrement(IndexSeq()); }
+
+  const std::tuple<FirstRange, Ranges...>* ranges_;
+  std::tuple<RangeIteratorType<FirstRange>, RangeIteratorType<Ranges>...>
+      it_tuple_;
+};
+
+template <typename FirstRange, typename... Ranges>
+class NestedRange
+    : public AliasRangeFacade<NestedRange<FirstRange, Ranges...>,
+                              std::tuple<FirstRange, Ranges...>,
+                              NestedIterator<FirstRange, Ranges...>> {
+  static_assert(
+      std::is_convertible_v<nested_range_detail::InnerRangeCategory<Ranges...>,
+                            std::forward_iterator_tag>,
+      "NestedRange requires inner ranges to be at least forward iterators "
+      "(multi-pass).");
+
+ public:
+  using BaseRange = std::tuple<FirstRange, Ranges...>;
+  using NestedIter = NestedIterator<FirstRange, Ranges...>;
+  using BaseFacade = AliasRangeFacade<NestedRange<FirstRange, Ranges...>,
+                                      BaseRange, NestedIter>;
+
+  template <typename... OtherRanges>
+  explicit NestedRange(OtherRanges&&... ranges)
+      : BaseFacade(std::tuple<FirstRange, Ranges...>(
+            std::forward<OtherRanges>(ranges)...)) {}
+
+ private:
+  friend class AliasRangeFacadePrivateAccess<
+      NestedRange<FirstRange, Ranges...>>;
+
+  auto Begin(const BaseRange& base_range) const {
+    return NestedIter(nested_range_detail::BeginTag{}, &base_range);
+  }
+  auto End(const BaseRange& base_range) const {
+    return NestedIter(nested_range_detail::EndTag{}, &base_range);
+  }
 };
 
 // Deduction guide
 template <typename... OtherRanges>
 NestedRange(OtherRanges&&... ranges)
-    -> NestedRange<std::decay_t<OtherRanges>...>;
+    -> NestedRange<RangeDecayType<OtherRanges>...>;
 
 // Deduction function to create NestedRange for older compilers (gcc<11).
 template <typename... OtherRanges>
 auto MakeNestedRange(OtherRanges&&... ranges) {
-  return NestedRange<std::decay_t<OtherRanges>...>(
+  return NestedRange<RangeDecayType<OtherRanges>...>(
       std::forward<OtherRanges>(ranges)...);
 }
 
-// Convenience wrapper to nest a sequence of ranges.  Keeps a
-// light-weight copy to the supplied range (avoids a deep copy).  This works on
-// ranges on which calling MakeIteratorRange() makes sense.
+// Convenience wrapper to nest a sequence of ranges. Keeps a
+// iterator pairs to the supplied ranges if they are lvalue references.
+// Makes a copy/move of the supplied ranges if they are rvalue references.
 template <typename... Containers>
 auto NestRanges(Containers&&... ranges) {
-  return MakeNestedRange(
-      MakeIteratorRange(std::forward<Containers>(ranges))...);
+  return MakeNestedRange(MoveOrAliasRange(std::forward<Containers>(ranges))...);
 }
 
 }  // namespace genit

--- a/genit/transform_iterator.h
+++ b/genit/transform_iterator.h
@@ -21,7 +21,6 @@
 
 #include "genit/iterator_facade.h"
 #include "genit/iterator_range.h"
-#include "iterator_range.h"
 
 namespace genit {
 


### PR DESCRIPTION
Use ranges consistently to solve life-time issues

This PR pretty much changes the library from an iterators-first library to a ranges-first library to resolve some of the life-time issues that arise from trying to transform and forward iterators that are tied to ranges. Essentially, for all the same reasons why the std::ranges library is not the std::iterators library. So, this PR introduces a range facade class and creates a range class for each iterator type that didn't already have one and rather than carry mappings of iterators it carries mappings of ranges that produce mapped iterators at the end when used in a for-loop. This also solves the annoying issue with lambda's not being default-constructible or assignable (until C++20).